### PR TITLE
allow expanded NPC and sprite tables

### DIFF
--- a/src/ebhack/MapEditor.java
+++ b/src/ebhack/MapEditor.java
@@ -2146,14 +2146,12 @@ public class MapEditor extends ToolModule implements ActionListener,
 			while (true) {
 				spriteGroups.add(new Image[4]);
 				try {
-					// TODO: this was using proj.getFilename. Why does that even exist?
-					String filename = proj.getDirectory() + File.separator + "SpriteGroups" + File.separator
-							+ ToolModule.addZeros(i + "", 3) + ".png";
-					File file = new File(filename);
-					if (!file.exists()) {
+					String spriteResourceFid = "SpriteGroups/" + ToolModule.addZeros(i + "", 3);
+					String spriteFilename = proj.getFilenameOrNull("eb.SpriteGroupModule", spriteResourceFid);
+					if (spriteFilename == null) {
 						break;
 					}
-					BufferedImage sheet = ImageIO.read(new File(filename));
+					BufferedImage sheet = ImageIO.read(new File(spriteFilename));
 					Graphics2D sg = sheet.createGraphics();
 
 					w = sheet.getWidth() / 4;

--- a/src/ebhack/SpriteLoader.java
+++ b/src/ebhack/SpriteLoader.java
@@ -5,13 +5,14 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 
 import javax.imageio.ImageIO;
 
 public class SpriteLoader extends ToolModule {
-	private static Image[][] sprites = new Image[464][4];;
-	private static int[] widths = new int[464];
-	private static int[] heights = new int[464];
+	private static ArrayList<Image[]> sprites = new ArrayList<Image[]>();
+	private static ArrayList<Integer> widths = new ArrayList<Integer>();
+	private static ArrayList<Integer> heights = new ArrayList<Integer>();
 
 	public SpriteLoader(YMLPreferences prefs) {
 		super(prefs);
@@ -36,30 +37,32 @@ public class SpriteLoader extends ToolModule {
 	}
 	
 	public static Image getSprite(int n, int direction) {
-		return sprites[n][direction];
+		return sprites.get(n)[direction];
 	}
 	
 	public static int getSpriteW(int n) {
-		return widths[n];
+		return widths.get(n);
 	}
 	
 	public static int getSpriteH(int n) {
-		return heights[n];
+		return heights.get(n);
 	}
 
 	public void load(Project proj) {
 		int w, h, x, y, z;
-		for (int i = 0; i < sprites.length; ++i) {
-			sprites[i] = new Image[4];
+		// TODO: this needs to be updated to be dynamic, but on testing it seems like this code is
+		// never actually run. I'm stopping here because it's working.
+		for (int i = 0; i < 464; ++i) {
+			sprites.add(new Image[4]);
 			try {
 				BufferedImage sheet = ImageIO.read(new File(proj.getFilename(
 						"eb.SpriteGroupModule",
 						"SpriteGroups/" + ToolModule.addZeros(i+"", 3))));
 				Graphics2D sg = sheet.createGraphics();
 				w = sheet.getWidth()/4;
-				widths[i] = w;
+				widths.add(w);
 				h = sheet.getHeight()/4;
-				heights[i] = h;
+				heights.add(h);
 				z = 0;
 				for (y=0; y<2; ++y) {
 					for (x=0; x<4; x += 2) {
@@ -68,7 +71,7 @@ public class SpriteLoader extends ToolModule {
 						g.setComposite(sg.getComposite());
 						g.drawImage(sheet, 0, 0, w, h, w*x, h*y, w*x+w, h*y+h, null);
 						g.dispose();
-						sprites[i][z] = sp;
+						sprites.get(i)[z] = sp;
 						++z;
 					}
 				}


### PR DESCRIPTION
This goes along with a change I made in the CoilSnake repository. NPCs and sprites can now be expanded.

EbProjectEditor really needs a cleanup, and this change is not it. It's just what's needed to get the feature working.

This was also kind of complex (doesn't look like it but EbProjectEditor is silently eating most stack traces somewhere), so please double check the code and test it to make sure I pulled all the files, etc.

Also I'm not sure if SpriteLoader is ever used? I left my changes in because they're probably about right. It's hard to tell what's going on because something keeps silently eating stack traces.