### PR TITLE
Smooth map scrolling, out of bounds map scrolling, and more

### DIFF
--- a/src/ebhack/MapData.java
+++ b/src/ebhack/MapData.java
@@ -7,10 +7,8 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.*;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
 
 public class MapData {
     public static final int WIDTH_IN_TILES = 32 * 8;
@@ -21,6 +19,7 @@ public class MapData {
             / SECTOR_WIDTH;
     public static final int HEIGHT_IN_SECTORS = HEIGHT_IN_TILES
             / SECTOR_HEIGHT;
+    public static final int HEIGHT_IN_DOUBLE_SECTORS = HEIGHT_IN_TILES / (SECTOR_HEIGHT * 2);
     public static final int TILE_WIDTH = 32;
     public static final int TILE_HEIGHT = 32;
 
@@ -48,11 +47,11 @@ public class MapData {
         for (int i = 0; i < sectors.length; ++i)
             for (int j = 0; j < sectors[i].length; ++j)
                 sectors[i][j] = new Sector();
-        spriteAreas = new ArrayList[HEIGHT_IN_SECTORS / 2][WIDTH_IN_SECTORS];
+        spriteAreas = new ArrayList[HEIGHT_IN_DOUBLE_SECTORS][WIDTH_IN_SECTORS];
         for (int i = 0; i < spriteAreas.length; ++i)
             for (int j = 0; j < spriteAreas[i].length; ++j)
                 spriteAreas[i][j] = new ArrayList<SpriteEntry>();
-        doorAreas = new ArrayList[HEIGHT_IN_SECTORS / 2][WIDTH_IN_SECTORS];
+        doorAreas = new ArrayList[HEIGHT_IN_DOUBLE_SECTORS][WIDTH_IN_SECTORS];
         for (int i = 0; i < doorAreas.length; ++i)
             for (int j = 0; j < doorAreas[i].length; ++j)
                 doorAreas[i][j] = new ArrayList<Door>();
@@ -146,13 +145,21 @@ public class MapData {
             spriteAreas[areaY][areaX].add(new SpriteEntry(x, y, npcid));
     }
 
-    public java.util.List<SpriteEntry> getSpriteArea(int areaX, int areaY) {
+    public List<SpriteEntry> getSpriteArea(int areaX, int areaY) {
+        if (areaX < 0 || areaX >= WIDTH_IN_SECTORS
+                || areaY < 0 || areaY >= HEIGHT_IN_DOUBLE_SECTORS) {
+            return Collections.emptyList();
+        }
         return spriteAreas[areaY][areaX];
     }
 
     // Door Editing
 
     public java.util.List<Door> getDoorArea(int areaX, int areaY) {
+        if (areaX < 0 || areaX >= WIDTH_IN_SECTORS
+                || areaY < 0 || areaY >= HEIGHT_IN_DOUBLE_SECTORS) {
+            return Collections.emptyList();
+        }
         return doorAreas[areaY][areaX];
     }
 

--- a/src/ebhack/MapDisplay.java
+++ b/src/ebhack/MapDisplay.java
@@ -271,36 +271,30 @@ public class MapDisplay extends AbstractButton implements
         if (currentMode.drawSprites()) {
             MapData.NPC npc;
             Integer[] wh;
-            java.util.List<MapData.SpriteEntry> area;
             for (int iy = y & (~7); iy < (y & (~7)) + screenHeight + 8; iy += 8) {
                 for (int ix = x & (~7); ix < (x & (~7)) + screenWidth + 8; ix += 8) {
-                    try {
-                        area = map.getSpriteArea(ix >> 3, iy >> 3);
-                        for (MapData.SpriteEntry e : area) {
-                            npc = map.getNPC(e.npcID);
-                            wh = map.getSpriteWH(npc.sprite);
-                            if (spriteBoxes && !gamePreview) {
-                                g.setPaint(Color.RED);
-                                g.draw(new Rectangle2D.Double(e.x + (ix - x)
-                                        * MapData.TILE_WIDTH - wh[0] / 2,
-                                        e.y + (iy - y) * MapData.TILE_HEIGHT
-                                                - wh[1] + 8, wh[0] + 1,
-                                        wh[1] + 1));
-                            }
-                            g.drawImage(map.getSpriteImage(npc.sprite,
-                                            npc.direction), e.x + (ix - x)
-                                            * MapData.TILE_WIDTH - wh[0] / 2 + 1,
+                    for (MapData.SpriteEntry e : map.getSpriteArea(ix >> 3, iy >> 3)) {
+                        npc = map.getNPC(e.npcID);
+                        wh = map.getSpriteWH(npc.sprite);
+                        if (spriteBoxes && !gamePreview) {
+                            g.setPaint(Color.RED);
+                            g.draw(new Rectangle2D.Double(e.x + (ix - x)
+                                    * MapData.TILE_WIDTH - wh[0] / 2,
                                     e.y + (iy - y) * MapData.TILE_HEIGHT
-                                            - wh[1] + 9, this);
-                            if (drawSpriteNums && !gamePreview) {
-                                drawNumber(g, e.npcID, e.x + (ix - x)
-                                                * MapData.TILE_WIDTH - wh[0] / 2,
-                                        e.y + (iy - y) * MapData.TILE_HEIGHT
-                                                - wh[1] + 8, false, true);
-                            }
+                                            - wh[1] + 8, wh[0] + 1,
+                                    wh[1] + 1));
                         }
-                    } catch (Exception e) {
-
+                        g.drawImage(map.getSpriteImage(npc.sprite,
+                                        npc.direction), e.x + (ix - x)
+                                        * MapData.TILE_WIDTH - wh[0] / 2 + 1,
+                                e.y + (iy - y) * MapData.TILE_HEIGHT
+                                        - wh[1] + 9, this);
+                        if (drawSpriteNums && !gamePreview) {
+                            drawNumber(g, e.npcID, e.x + (ix - x)
+                                            * MapData.TILE_WIDTH - wh[0] / 2,
+                                    e.y + (iy - y) * MapData.TILE_HEIGHT
+                                            - wh[1] + 8, false, true);
+                        }
                     }
                 }
             }
@@ -317,33 +311,27 @@ public class MapDisplay extends AbstractButton implements
         }
 
         if (currentMode.drawDoors()) {
-            List<MapData.Door> area;
             for (int iy = y & (~7); iy < (y & (~7)) + screenHeight + 8; iy += 8) {
                 for (int ix = x & (~7); ix < (x & (~7)) + screenWidth + 8; ix += 8) {
-                    try {
-                        area = map.getDoorArea(ix >> 3, iy >> 3);
-                        for (MapData.Door e : area) {
-                            g.setPaint(e.getColor());
-                            g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
-                                    * MapData.TILE_WIDTH + 1, e.y * 8
-                                    + (iy - y) * MapData.TILE_HEIGHT + 1, 8,
-                                    8));
-                            g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
-                                    * MapData.TILE_WIDTH + 3, e.y * 8
-                                    + (iy - y) * MapData.TILE_HEIGHT + 3, 4,
-                                    4));
-                            g.setPaint(Color.WHITE);
-                            g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
-                                    * MapData.TILE_WIDTH + 2, e.y * 8
-                                    + (iy - y) * MapData.TILE_HEIGHT + 2, 6,
-                                    6));
-                            g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
-                                    * MapData.TILE_WIDTH + 4, e.y * 8
-                                    + (iy - y) * MapData.TILE_HEIGHT + 4, 2,
-                                    2));
-                        }
-                    } catch (Exception e) {
-
+                    for (MapData.Door e : map.getDoorArea(ix >> 3, iy >> 3)) {
+                        g.setPaint(e.getColor());
+                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
+                                * MapData.TILE_WIDTH + 1, e.y * 8
+                                + (iy - y) * MapData.TILE_HEIGHT + 1, 8,
+                                8));
+                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
+                                * MapData.TILE_WIDTH + 3, e.y * 8
+                                + (iy - y) * MapData.TILE_HEIGHT + 3, 4,
+                                4));
+                        g.setPaint(Color.WHITE);
+                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
+                                * MapData.TILE_WIDTH + 2, e.y * 8
+                                + (iy - y) * MapData.TILE_HEIGHT + 2, 6,
+                                6));
+                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
+                                * MapData.TILE_WIDTH + 4, e.y * 8
+                                + (iy - y) * MapData.TILE_HEIGHT + 4, 2,
+                                2));
                     }
                 }
             }

--- a/src/ebhack/MapDisplay.java
+++ b/src/ebhack/MapDisplay.java
@@ -220,23 +220,23 @@ public class MapDisplay extends AbstractButton implements
 
         MapData.Sector sector;
         int pal;
-        for (int i = 0; i < screenHeight; i++) {
-            for (int j = 0; j < screenWidth; j++) {
-                sector = map.getSector((j + x) / MapData.SECTOR_WIDTH,
-                        (i + y) / MapData.SECTOR_HEIGHT);
+        for (int iy = 0; iy < screenHeight; iy++) {
+            for (int ix = 0; ix < screenWidth; ix++) {
+                sector = map.getSector((ix + x) / MapData.SECTOR_WIDTH,
+                        (iy + y) / MapData.SECTOR_HEIGHT);
                 pal = TileEditor.tilesets[TileEditor
                         .getDrawTilesetNumber(sector.tileset)]
                         .getPaletteNum(sector.tileset, sector.palette);
                 g.drawImage(
                         getTileImage(TileEditor
                                 .getDrawTilesetNumber(sector.tileset), map
-                                .getMapTile(x + j, y + i), pal), j
-                                * MapData.TILE_WIDTH + 1, i
+                                .getMapTile(x + ix, y + iy), pal), ix
+                                * MapData.TILE_WIDTH + 1, iy
                                 * MapData.TILE_HEIGHT + 1,
                         MapData.TILE_WIDTH, MapData.TILE_HEIGHT, this);
                 if (drawTileNums && !gamePreview) {
-                    drawNumber(g, map.getMapTile(x + j, y + i), j
-                            * MapData.TILE_WIDTH + 1, i
+                    drawNumber(g, map.getMapTile(x + ix, y + iy), ix
+                            * MapData.TILE_WIDTH + 1, iy
                             * MapData.TILE_HEIGHT + 1, false, false);
                 }
             }
@@ -272,30 +272,30 @@ public class MapDisplay extends AbstractButton implements
             MapData.NPC npc;
             Integer[] wh;
             java.util.List<MapData.SpriteEntry> area;
-            for (int i = y & (~7); i < (y & (~7)) + screenHeight + 8; i += 8) {
-                for (int j = x & (~7); j < (x & (~7)) + screenWidth + 8; j += 8) {
+            for (int iy = y & (~7); iy < (y & (~7)) + screenHeight + 8; iy += 8) {
+                for (int ix = x & (~7); ix < (x & (~7)) + screenWidth + 8; ix += 8) {
                     try {
-                        area = map.getSpriteArea(j >> 3, i >> 3);
+                        area = map.getSpriteArea(ix >> 3, iy >> 3);
                         for (MapData.SpriteEntry e : area) {
                             npc = map.getNPC(e.npcID);
                             wh = map.getSpriteWH(npc.sprite);
                             if (spriteBoxes && !gamePreview) {
                                 g.setPaint(Color.RED);
-                                g.draw(new Rectangle2D.Double(e.x + (j - x)
+                                g.draw(new Rectangle2D.Double(e.x + (ix - x)
                                         * MapData.TILE_WIDTH - wh[0] / 2,
-                                        e.y + (i - y) * MapData.TILE_HEIGHT
+                                        e.y + (iy - y) * MapData.TILE_HEIGHT
                                                 - wh[1] + 8, wh[0] + 1,
                                         wh[1] + 1));
                             }
                             g.drawImage(map.getSpriteImage(npc.sprite,
-                                            npc.direction), e.x + (j - x)
+                                            npc.direction), e.x + (ix - x)
                                             * MapData.TILE_WIDTH - wh[0] / 2 + 1,
-                                    e.y + (i - y) * MapData.TILE_HEIGHT
+                                    e.y + (iy - y) * MapData.TILE_HEIGHT
                                             - wh[1] + 9, this);
                             if (drawSpriteNums && !gamePreview) {
-                                drawNumber(g, e.npcID, e.x + (j - x)
+                                drawNumber(g, e.npcID, e.x + (ix - x)
                                                 * MapData.TILE_WIDTH - wh[0] / 2,
-                                        e.y + (i - y) * MapData.TILE_HEIGHT
+                                        e.y + (iy - y) * MapData.TILE_HEIGHT
                                                 - wh[1] + 8, false, true);
                             }
                         }
@@ -318,28 +318,28 @@ public class MapDisplay extends AbstractButton implements
 
         if (currentMode.drawDoors()) {
             List<MapData.Door> area;
-            for (int i = y & (~7); i < (y & (~7)) + screenHeight + 8; i += 8) {
-                for (int j = x & (~7); j < (x & (~7)) + screenWidth + 8; j += 8) {
+            for (int iy = y & (~7); iy < (y & (~7)) + screenHeight + 8; iy += 8) {
+                for (int ix = x & (~7); ix < (x & (~7)) + screenWidth + 8; ix += 8) {
                     try {
-                        area = map.getDoorArea(j >> 3, i >> 3);
+                        area = map.getDoorArea(ix >> 3, iy >> 3);
                         for (MapData.Door e : area) {
                             g.setPaint(e.getColor());
-                            g.draw(new Rectangle2D.Double(e.x * 8 + (j - x)
+                            g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
                                     * MapData.TILE_WIDTH + 1, e.y * 8
-                                    + (i - y) * MapData.TILE_HEIGHT + 1, 8,
+                                    + (iy - y) * MapData.TILE_HEIGHT + 1, 8,
                                     8));
-                            g.draw(new Rectangle2D.Double(e.x * 8 + (j - x)
+                            g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
                                     * MapData.TILE_WIDTH + 3, e.y * 8
-                                    + (i - y) * MapData.TILE_HEIGHT + 3, 4,
+                                    + (iy - y) * MapData.TILE_HEIGHT + 3, 4,
                                     4));
                             g.setPaint(Color.WHITE);
-                            g.draw(new Rectangle2D.Double(e.x * 8 + (j - x)
+                            g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
                                     * MapData.TILE_WIDTH + 2, e.y * 8
-                                    + (i - y) * MapData.TILE_HEIGHT + 2, 6,
+                                    + (iy - y) * MapData.TILE_HEIGHT + 2, 6,
                                     6));
-                            g.draw(new Rectangle2D.Double(e.x * 8 + (j - x)
+                            g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
                                     * MapData.TILE_WIDTH + 4, e.y * 8
-                                    + (i - y) * MapData.TILE_HEIGHT + 4, 2,
+                                    + (iy - y) * MapData.TILE_HEIGHT + 4, 2,
                                     2));
                         }
                     } catch (Exception e) {
@@ -378,11 +378,11 @@ public class MapDisplay extends AbstractButton implements
 
         if (currentMode.drawEnemies()) {
             g.setFont(new Font("Arial", Font.PLAIN, 12));
-            for (int i = -(y % 2); i < screenHeight; i += 2) {
-                for (int j = -(x % 2); j < screenWidth; j += 2) {
+            for (int iy = -(y % 2); iy < screenHeight; iy += 2) {
+                for (int ix = -(x % 2); ix < screenWidth; ix += 2) {
                     // Draw the grid
-                    Rectangle2D rect = new Rectangle2D.Double(j
-                            * MapData.TILE_WIDTH + 1, i
+                    Rectangle2D rect = new Rectangle2D.Double(ix
+                            * MapData.TILE_WIDTH + 1, iy
                             * MapData.TILE_HEIGHT + 1,
                             MapData.TILE_WIDTH * 2, MapData.TILE_HEIGHT * 2);
                     if (grid && !gamePreview) {
@@ -390,16 +390,16 @@ public class MapDisplay extends AbstractButton implements
                         g.draw(rect);
                     }
 
-                    int a = map.getMapEnemyGroup((x + j) / 2, (y + i) / 2);
-                    if (a != 0) {
+                    int enemyGroup = map.getMapEnemyGroup((x + ix) / 2, (y + iy) / 2);
+                    if (enemyGroup != 0) {
                         g.setComposite(AlphaComposite.getInstance(
                                 AlphaComposite.SRC_OVER, 0.5F));
-                        g.setPaint(enemyColors[a]);
+                        g.setPaint(enemyColors[enemyGroup]);
                         g.fill(rect);
 
                         g.setComposite(AlphaComposite.getInstance(
                                 AlphaComposite.SRC_OVER, 1.0F));
-                        drawNumber(g, a, j * MapData.TILE_WIDTH + 1, i
+                        drawNumber(g, enemyGroup, ix * MapData.TILE_WIDTH + 1, iy
                                 * MapData.TILE_HEIGHT + 1, false, false);
                     }
                 }

--- a/src/ebhack/MapDisplay.java
+++ b/src/ebhack/MapDisplay.java
@@ -215,14 +215,13 @@ public class MapDisplay extends AbstractButton implements
     }
 
     private void drawMap(Graphics2D g) {
-        int i, j, a;
         g.setPaint(Color.white);
         g.setFont(new Font("Arial", Font.PLAIN, 12));
 
         MapData.Sector sector;
         int pal;
-        for (i = 0; i < screenHeight; i++) {
-            for (j = 0; j < screenWidth; j++) {
+        for (int i = 0; i < screenHeight; i++) {
+            for (int j = 0; j < screenWidth; j++) {
                 sector = map.getSector((j + x) / MapData.SECTOR_WIDTH,
                         (i + y) / MapData.SECTOR_HEIGHT);
                 pal = TileEditor.tilesets[TileEditor
@@ -273,8 +272,8 @@ public class MapDisplay extends AbstractButton implements
             MapData.NPC npc;
             Integer[] wh;
             java.util.List<MapData.SpriteEntry> area;
-            for (i = y & (~7); i < (y & (~7)) + screenHeight + 8; i += 8) {
-                for (j = x & (~7); j < (x & (~7)) + screenWidth + 8; j += 8) {
+            for (int i = y & (~7); i < (y & (~7)) + screenHeight + 8; i += 8) {
+                for (int j = x & (~7); j < (x & (~7)) + screenWidth + 8; j += 8) {
                     try {
                         area = map.getSpriteArea(j >> 3, i >> 3);
                         for (MapData.SpriteEntry e : area) {
@@ -319,8 +318,8 @@ public class MapDisplay extends AbstractButton implements
 
         if (currentMode.drawDoors()) {
             List<MapData.Door> area;
-            for (i = y & (~7); i < (y & (~7)) + screenHeight + 8; i += 8) {
-                for (j = x & (~7); j < (x & (~7)) + screenWidth + 8; j += 8) {
+            for (int i = y & (~7); i < (y & (~7)) + screenHeight + 8; i += 8) {
+                for (int j = x & (~7); j < (x & (~7)) + screenWidth + 8; j += 8) {
                     try {
                         area = map.getDoorArea(j >> 3, i >> 3);
                         for (MapData.Door e : area) {
@@ -379,8 +378,8 @@ public class MapDisplay extends AbstractButton implements
 
         if (currentMode.drawEnemies()) {
             g.setFont(new Font("Arial", Font.PLAIN, 12));
-            for (i = -(y % 2); i < screenHeight; i += 2) {
-                for (j = -(x % 2); j < screenWidth; j += 2) {
+            for (int i = -(y % 2); i < screenHeight; i += 2) {
+                for (int j = -(x % 2); j < screenWidth; j += 2) {
                     // Draw the grid
                     Rectangle2D rect = new Rectangle2D.Double(j
                             * MapData.TILE_WIDTH + 1, i
@@ -391,7 +390,7 @@ public class MapDisplay extends AbstractButton implements
                         g.draw(rect);
                     }
 
-                    a = map.getMapEnemyGroup((x + j) / 2, (y + i) / 2);
+                    int a = map.getMapEnemyGroup((x + j) / 2, (y + i) / 2);
                     if (a != 0) {
                         g.setComposite(AlphaComposite.getInstance(
                                 AlphaComposite.SRC_OVER, 0.5F));
@@ -412,7 +411,7 @@ public class MapDisplay extends AbstractButton implements
             g.setComposite(AlphaComposite.getInstance(
                     AlphaComposite.SRC_OVER, 0.8F));
             int tx1, ty1, tx2, ty2;
-            for (i = 0; i < map.numHotspots(); ++i) {
+            for (int i = 0; i < map.numHotspots(); ++i) {
                 hs = map.getHotspot(i);
                 if (hs == editHS)
                     continue;

--- a/src/ebhack/MapDisplay.java
+++ b/src/ebhack/MapDisplay.java
@@ -5,7 +5,6 @@ import java.awt.*;
 import java.awt.event.*;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.util.List;
 import java.util.Stack;
 
 public class MapDisplay extends AbstractButton implements
@@ -53,7 +52,7 @@ public class MapDisplay extends AbstractButton implements
     private int screenHeight = 12;
 
     // Map X and Y coordinates of the tile displayed in the top left corner
-    private int x = 0, y = 0;
+    private int screenX = 0, screenY = 0;
     // Data for the selected sector
     private MapData.Sector selectedSector = null;
     private int sectorX, sectorY;
@@ -222,20 +221,20 @@ public class MapDisplay extends AbstractButton implements
         int pal;
         for (int iy = 0; iy < screenHeight; iy++) {
             for (int ix = 0; ix < screenWidth; ix++) {
-                sector = map.getSector((ix + x) / MapData.SECTOR_WIDTH,
-                        (iy + y) / MapData.SECTOR_HEIGHT);
+                sector = map.getSector((ix + screenX) / MapData.SECTOR_WIDTH,
+                        (iy + screenY) / MapData.SECTOR_HEIGHT);
                 pal = TileEditor.tilesets[TileEditor
                         .getDrawTilesetNumber(sector.tileset)]
                         .getPaletteNum(sector.tileset, sector.palette);
                 g.drawImage(
                         getTileImage(TileEditor
                                 .getDrawTilesetNumber(sector.tileset), map
-                                .getMapTile(x + ix, y + iy), pal), ix
+                                .getMapTile(screenX + ix, screenY + iy), pal), ix
                                 * MapData.TILE_WIDTH + 1, iy
                                 * MapData.TILE_HEIGHT + 1,
                         MapData.TILE_WIDTH, MapData.TILE_HEIGHT, this);
                 if (drawTileNums && !gamePreview) {
-                    drawNumber(g, map.getMapTile(x + ix, y + iy), ix
+                    drawNumber(g, map.getMapTile(screenX + ix, screenY + iy), ix
                             * MapData.TILE_WIDTH + 1, iy
                             * MapData.TILE_HEIGHT + 1, false, false);
                 }
@@ -248,14 +247,14 @@ public class MapDisplay extends AbstractButton implements
         if (currentMode == MapMode.MAP && (selectedSector != null)) {
             int sXt, sYt;
             if (((sXt = sectorX * MapData.SECTOR_WIDTH)
-                    + MapData.SECTOR_WIDTH >= x)
-                    && (sXt < x + screenWidth)
+                    + MapData.SECTOR_WIDTH >= screenX)
+                    && (sXt < screenX + screenWidth)
                     && ((sYt = sectorY * MapData.SECTOR_HEIGHT)
-                    + MapData.SECTOR_HEIGHT >= y)
-                    && (sYt < y + screenHeight)) {
+                    + MapData.SECTOR_HEIGHT >= screenY)
+                    && (sYt < screenY + screenHeight)) {
                 g.setPaint(Color.yellow);
-                g.draw(new Rectangle2D.Double((sXt - x)
-                        * MapData.TILE_WIDTH + 1, (sYt - y)
+                g.draw(new Rectangle2D.Double((sXt - screenX)
+                        * MapData.TILE_WIDTH + 1, (sYt - screenY)
                         * MapData.TILE_HEIGHT + 1, MapData.SECTOR_WIDTH
                         * MapData.TILE_WIDTH, MapData.SECTOR_HEIGHT
                         * MapData.TILE_HEIGHT));
@@ -271,28 +270,28 @@ public class MapDisplay extends AbstractButton implements
         if (currentMode.drawSprites()) {
             MapData.NPC npc;
             Integer[] wh;
-            for (int iy = y & (~7); iy < (y & (~7)) + screenHeight + 8; iy += 8) {
-                for (int ix = x & (~7); ix < (x & (~7)) + screenWidth + 8; ix += 8) {
+            for (int iy = screenY & (~7); iy < (screenY & (~7)) + screenHeight + 8; iy += 8) {
+                for (int ix = screenX & (~7); ix < (screenX & (~7)) + screenWidth + 8; ix += 8) {
                     for (MapData.SpriteEntry e : map.getSpriteArea(ix >> 3, iy >> 3)) {
                         npc = map.getNPC(e.npcID);
                         wh = map.getSpriteWH(npc.sprite);
                         if (spriteBoxes && !gamePreview) {
                             g.setPaint(Color.RED);
-                            g.draw(new Rectangle2D.Double(e.x + (ix - x)
+                            g.draw(new Rectangle2D.Double(e.x + (ix - screenX)
                                     * MapData.TILE_WIDTH - wh[0] / 2,
-                                    e.y + (iy - y) * MapData.TILE_HEIGHT
+                                    e.y + (iy - screenY) * MapData.TILE_HEIGHT
                                             - wh[1] + 8, wh[0] + 1,
                                     wh[1] + 1));
                         }
                         g.drawImage(map.getSpriteImage(npc.sprite,
-                                        npc.direction), e.x + (ix - x)
+                                        npc.direction), e.x + (ix - screenX)
                                         * MapData.TILE_WIDTH - wh[0] / 2 + 1,
-                                e.y + (iy - y) * MapData.TILE_HEIGHT
+                                e.y + (iy - screenY) * MapData.TILE_HEIGHT
                                         - wh[1] + 9, this);
                         if (drawSpriteNums && !gamePreview) {
-                            drawNumber(g, e.npcID, e.x + (ix - x)
+                            drawNumber(g, e.npcID, e.x + (ix - screenX)
                                             * MapData.TILE_WIDTH - wh[0] / 2,
-                                    e.y + (iy - y) * MapData.TILE_HEIGHT
+                                    e.y + (iy - screenY) * MapData.TILE_HEIGHT
                                             - wh[1] + 8, false, true);
                         }
                     }
@@ -311,26 +310,26 @@ public class MapDisplay extends AbstractButton implements
         }
 
         if (currentMode.drawDoors()) {
-            for (int iy = y & (~7); iy < (y & (~7)) + screenHeight + 8; iy += 8) {
-                for (int ix = x & (~7); ix < (x & (~7)) + screenWidth + 8; ix += 8) {
+            for (int iy = screenY & (~7); iy < (screenY & (~7)) + screenHeight + 8; iy += 8) {
+                for (int ix = screenX & (~7); ix < (screenX & (~7)) + screenWidth + 8; ix += 8) {
                     for (MapData.Door e : map.getDoorArea(ix >> 3, iy >> 3)) {
                         g.setPaint(e.getColor());
-                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
+                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - screenX)
                                 * MapData.TILE_WIDTH + 1, e.y * 8
-                                + (iy - y) * MapData.TILE_HEIGHT + 1, 8,
+                                + (iy - screenY) * MapData.TILE_HEIGHT + 1, 8,
                                 8));
-                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
+                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - screenX)
                                 * MapData.TILE_WIDTH + 3, e.y * 8
-                                + (iy - y) * MapData.TILE_HEIGHT + 3, 4,
+                                + (iy - screenY) * MapData.TILE_HEIGHT + 3, 4,
                                 4));
                         g.setPaint(Color.WHITE);
-                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
+                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - screenX)
                                 * MapData.TILE_WIDTH + 2, e.y * 8
-                                + (iy - y) * MapData.TILE_HEIGHT + 2, 6,
+                                + (iy - screenY) * MapData.TILE_HEIGHT + 2, 6,
                                 6));
-                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - x)
+                        g.draw(new Rectangle2D.Double(e.x * 8 + (ix - screenX)
                                 * MapData.TILE_WIDTH + 4, e.y * 8
-                                + (iy - y) * MapData.TILE_HEIGHT + 4, 2,
+                                + (iy - screenY) * MapData.TILE_HEIGHT + 4, 2,
                                 2));
                     }
                 }
@@ -366,8 +365,8 @@ public class MapDisplay extends AbstractButton implements
 
         if (currentMode.drawEnemies()) {
             g.setFont(new Font("Arial", Font.PLAIN, 12));
-            for (int iy = -(y % 2); iy < screenHeight; iy += 2) {
-                for (int ix = -(x % 2); ix < screenWidth; ix += 2) {
+            for (int iy = -(screenY % 2); iy < screenHeight; iy += 2) {
+                for (int ix = -(screenX % 2); ix < screenWidth; ix += 2) {
                     // Draw the grid
                     Rectangle2D rect = new Rectangle2D.Double(ix
                             * MapData.TILE_WIDTH + 1, iy
@@ -378,7 +377,7 @@ public class MapDisplay extends AbstractButton implements
                         g.draw(rect);
                     }
 
-                    int enemyGroup = map.getMapEnemyGroup((x + ix) / 2, (y + iy) / 2);
+                    int enemyGroup = map.getMapEnemyGroup((screenX + ix) / 2, (screenY + iy) / 2);
                     if (enemyGroup != 0) {
                         g.setComposite(AlphaComposite.getInstance(
                                 AlphaComposite.SRC_OVER, 0.5F));
@@ -403,22 +402,22 @@ public class MapDisplay extends AbstractButton implements
                 hs = map.getHotspot(i);
                 if (hs == editHS)
                     continue;
-                tx1 = hs.x1 / 4 - x;
-                ty1 = hs.y1 / 4 - y;
-                tx2 = hs.x2 / 4 - x;
-                ty2 = hs.y2 / 4 - y;
+                tx1 = hs.x1 / 4 - screenX;
+                ty1 = hs.y1 / 4 - screenY;
+                tx2 = hs.x2 / 4 - screenX;
+                ty2 = hs.y2 / 4 - screenY;
                 if (((tx1 >= 0) && (tx1 <= screenWidth) && (ty1 >= 0) && (ty1 <= screenHeight))
                         || ((tx2 >= 0) && (tx2 <= screenWidth)
                         && (ty2 >= 0) && (ty2 <= screenHeight))) {
                     g.setPaint(Color.PINK);
-                    g.fill(new Rectangle2D.Double(hs.x1 * 8 - x
-                            * MapData.TILE_WIDTH + 1, hs.y1 * 8 - y
+                    g.fill(new Rectangle2D.Double(hs.x1 * 8 - screenX
+                            * MapData.TILE_WIDTH + 1, hs.y1 * 8 - screenY
                             * MapData.TILE_HEIGHT + 1, (hs.x2 - hs.x1) * 8,
                             (hs.y2 - hs.y1) * 8));
 
                     drawNumber(g, i,
-                            hs.x1 * 8 - x * MapData.TILE_WIDTH + 1, hs.y1
-                                    * 8 - y * MapData.TILE_HEIGHT + 1,
+                            hs.x1 * 8 - screenX * MapData.TILE_WIDTH + 1, hs.y1
+                                    * 8 - screenY * MapData.TILE_HEIGHT + 1,
                             false, false);
                 }
             }
@@ -426,8 +425,8 @@ public class MapDisplay extends AbstractButton implements
             if (currentMode == MapMode.HOTSPOT && (editHS != null)) {
                 g.setPaint(Color.WHITE);
                 if (editHSx1 != -1) {
-                    tx1 = editHSx1 * 8 - x * MapData.TILE_WIDTH + 1;
-                    ty1 = editHSy1 * 8 - y * MapData.TILE_HEIGHT + 1;
+                    tx1 = editHSx1 * 8 - screenX * MapData.TILE_WIDTH + 1;
+                    ty1 = editHSy1 * 8 - screenY * MapData.TILE_HEIGHT + 1;
                     g.fill(new Rectangle2D.Double(tx1, ty1, hsMouseX - tx1,
                             hsMouseY - ty1));
                 } else {
@@ -560,24 +559,24 @@ public class MapDisplay extends AbstractButton implements
     public void setMapXY(int x, int y) {
         x = Math.max(0, x);
         y = Math.max(0, y);
-        this.x = Math.min(x, MapData.WIDTH_IN_TILES - screenWidth);
-        this.y = Math.min(y, MapData.HEIGHT_IN_TILES - screenHeight);
+        this.screenX = Math.min(x, MapData.WIDTH_IN_TILES - screenWidth);
+        this.screenY = Math.min(y, MapData.HEIGHT_IN_TILES - screenHeight);
     }
 
     public void setMapX(int x) {
-        setMapXY(x, y);
+        setMapXY(x, screenY);
     }
 
     public void setMapY(int y) {
-        setMapXY(x, y);
+        setMapXY(screenX, y);
     }
 
     public int getMapX() {
-        return x;
+        return screenX;
     }
 
     public int getMapY() {
-        return y;
+        return screenY;
     }
 
     public int getSectorX() {
@@ -622,8 +621,8 @@ public class MapDisplay extends AbstractButton implements
                 && (e.getY() <= screenHeight * MapData.TILE_HEIGHT + 2)) {
             if (currentMode == MapMode.MAP) {
                 if (e.getButton() == MouseEvent.BUTTON1) {
-                    int mX = (e.getX() - 1) / MapData.TILE_WIDTH + x;
-                    int mY = (e.getY() - 1) / MapData.TILE_HEIGHT + y;
+                    int mX = (e.getX() - 1) / MapData.TILE_WIDTH + screenX;
+                    int mY = (e.getY() - 1) / MapData.TILE_HEIGHT + screenY;
                     if (e.isShiftDown()) {
                         tileSelector.selectTile(map.getMapTile(mX, mY));
                     } else if (!e.isControlDown()) {
@@ -640,9 +639,9 @@ public class MapDisplay extends AbstractButton implements
                     }
                 } else if (e.getButton() == MouseEvent.BUTTON3) {
                     // Make sure they didn't click on the border
-                    int sX = (x + ((e.getX() - 1) / MapData.TILE_WIDTH))
+                    int sX = (screenX + ((e.getX() - 1) / MapData.TILE_WIDTH))
                             / MapData.SECTOR_WIDTH;
-                    int sY = (y + ((e.getY() - 1) / MapData.TILE_HEIGHT))
+                    int sY = (screenY + ((e.getY() - 1) / MapData.TILE_HEIGHT))
                             / MapData.SECTOR_HEIGHT;
                     selectSector(sX, sY);
                 }
@@ -660,9 +659,9 @@ public class MapDisplay extends AbstractButton implements
                         switchNPC.setEnabled(false);
                         moveNPC.setEnabled(false);
                     } else {
-                        final int areaX = ((x + popupX / MapData.TILE_WIDTH) / 8)
+                        final int areaX = ((screenX + popupX / MapData.TILE_WIDTH) / 8)
                                 * MapData.TILE_WIDTH * 8;
-                        final int areaY = ((y + popupY
+                        final int areaY = ((screenY + popupY
                                 / MapData.TILE_HEIGHT) / 8)
                                 * MapData.TILE_HEIGHT * 8;
                         detailsNPC.setText("Sprite @ ("
@@ -691,9 +690,9 @@ public class MapDisplay extends AbstractButton implements
                         editDoor.setEnabled(false);
                         jumpDoor.setEnabled(false);
                     } else {
-                        final int areaX = ((x + popupX / MapData.TILE_WIDTH) / MapData.SECTOR_WIDTH)
+                        final int areaX = ((screenX + popupX / MapData.TILE_WIDTH) / MapData.SECTOR_WIDTH)
                                 * MapData.SECTOR_WIDTH * (MapData.TILE_WIDTH / 8);
-                        final int areaY = ((y + popupY / MapData.TILE_HEIGHT) / (MapData.SECTOR_HEIGHT * 2))
+                        final int areaY = ((screenY + popupY / MapData.TILE_HEIGHT) / (MapData.SECTOR_HEIGHT * 2))
                                 * MapData.SECTOR_HEIGHT * (MapData.TILE_HEIGHT / 8);
                         detailsDoor.setText(ToolModule
                                 .capitalize(popupDoor.type)
@@ -711,14 +710,14 @@ public class MapDisplay extends AbstractButton implements
                     doorPopupMenu.show(this, e.getX(), e.getY());
                 }
             } else if (currentMode == MapMode.SEEK_DOOR) {
-                doorSeeker.seek(x * 4 + seekDrawX / 8, y * 4 + seekDrawY
+                doorSeeker.seek(screenX * 4 + seekDrawX / 8, screenY * 4 + seekDrawY
                         / 8);
                 doorSeeker = null;
                 changeMode(currentMode);
                 repaint();
             } else if (currentMode == MapMode.ENEMY) {
-                int eX = ((e.getX() - 1) / MapData.TILE_WIDTH + x) / 2;
-                int eY = ((e.getY() - 1) / MapData.TILE_HEIGHT + y) / 2;
+                int eX = ((e.getX() - 1) / MapData.TILE_WIDTH + screenX) / 2;
+                int eY = ((e.getY() - 1) / MapData.TILE_HEIGHT + screenY) / 2;
                 if (e.isShiftDown()) {
                     tileSelector.selectTile(map.getMapEnemyGroup(eX, eY));
                 } else {
@@ -727,8 +726,8 @@ public class MapDisplay extends AbstractButton implements
                     repaint();
                 }
             } else if (currentMode == MapMode.HOTSPOT) {
-                int mx = ((e.getX() - 1) / 8) + (x * 4), my = ((e.getY() - 1) / 8)
-                        + (y * 4);
+                int mx = ((e.getX() - 1) / 8) + (screenX * 4), my = ((e.getY() - 1) / 8)
+                        + (screenY * 4);
                 if (editHS != null) {
                     if (editHSx1 == -1) {
                         editHSx1 = mx;
@@ -783,8 +782,8 @@ public class MapDisplay extends AbstractButton implements
                 repaint();
             }
         } else if (ae.getActionCommand().equals("moveNPC")) {
-            int areaX = (x + popupX / MapData.TILE_WIDTH) / 8;
-            int areaY = (y + popupY / MapData.TILE_HEIGHT) / 8;
+            int areaX = (screenX + popupX / MapData.TILE_WIDTH) / 8;
+            int areaY = (screenY + popupY / MapData.TILE_HEIGHT) / 8;
 
             final int newSpriteX, newSpriteY;
 
@@ -829,31 +828,31 @@ public class MapDisplay extends AbstractButton implements
     // Sprites
     private MapData.SpriteEntry getSpriteEntryFromMouseXY(int mouseX,
                                                           int mouseY) {
-        int areaX = (x + mouseX / MapData.TILE_WIDTH) / 8, areaY = (y + mouseY
+        int areaX = (screenX + mouseX / MapData.TILE_WIDTH) / 8, areaY = (screenY + mouseY
                 / MapData.TILE_HEIGHT) / 8;
-        mouseX += (x % 8) * MapData.TILE_WIDTH;
+        mouseX += (screenX % 8) * MapData.TILE_WIDTH;
         mouseX %= (MapData.TILE_WIDTH * 8);
-        mouseY += (y % 8) * MapData.TILE_HEIGHT;
+        mouseY += (screenY % 8) * MapData.TILE_HEIGHT;
         mouseY %= (MapData.TILE_HEIGHT * 8);
         return map.getSpriteEntryFromCoords(areaX, areaY, mouseX, mouseY);
     }
 
     private int popNpcIdFromMouseXY(int mouseX, int mouseY) {
-        int areaX = (x + mouseX / MapData.TILE_WIDTH) / 8, areaY = (y + mouseY
+        int areaX = (screenX + mouseX / MapData.TILE_WIDTH) / 8, areaY = (screenY + mouseY
                 / MapData.TILE_HEIGHT) / 8;
-        mouseX += (x % 8) * MapData.TILE_WIDTH;
+        mouseX += (screenX % 8) * MapData.TILE_WIDTH;
         mouseX %= (MapData.TILE_WIDTH * 8);
-        mouseY += (y % 8) * MapData.TILE_HEIGHT;
+        mouseY += (screenY % 8) * MapData.TILE_HEIGHT;
         mouseY %= (MapData.TILE_HEIGHT * 8);
         return map.popNPCFromCoords(areaX, areaY, mouseX, mouseY);
     }
 
     private void pushNpcIdFromMouseXY(int npc, int mouseX, int mouseY) {
-        int areaX = (x + mouseX / MapData.TILE_WIDTH) / 8, areaY = (y + mouseY
+        int areaX = (screenX + mouseX / MapData.TILE_WIDTH) / 8, areaY = (screenY + mouseY
                 / MapData.TILE_HEIGHT) / 8;
-        mouseX += (x % 8) * MapData.TILE_WIDTH;
+        mouseX += (screenX % 8) * MapData.TILE_WIDTH;
         mouseX %= (MapData.TILE_WIDTH * 8);
-        mouseY += (y % 8) * MapData.TILE_HEIGHT;
+        mouseY += (screenY % 8) * MapData.TILE_HEIGHT;
         mouseY %= (MapData.TILE_HEIGHT * 8);
         map.pushNPCFromCoords(npc, areaX, areaY, mouseX, mouseY);
     }
@@ -868,32 +867,32 @@ public class MapDisplay extends AbstractButton implements
 
     // Doors
     private MapData.Door getDoorFromMouseXY(int mouseX, int mouseY) {
-        int areaX = (x + mouseX / MapData.TILE_WIDTH) / 8, areaY = (y + mouseY
+        int areaX = (screenX + mouseX / MapData.TILE_WIDTH) / 8, areaY = (screenY + mouseY
                 / MapData.TILE_HEIGHT) / 8;
-        mouseX += (x % 8) * MapData.TILE_WIDTH;
+        mouseX += (screenX % 8) * MapData.TILE_WIDTH;
         mouseX %= (MapData.TILE_WIDTH * 8);
-        mouseY += (y % 8) * MapData.TILE_HEIGHT;
+        mouseY += (screenY % 8) * MapData.TILE_HEIGHT;
         mouseY %= (MapData.TILE_HEIGHT * 8);
         return map.getDoorFromCoords(areaX, areaY, mouseX / 8, mouseY / 8);
     }
 
     private MapData.Door popDoorFromMouseXY(int mouseX, int mouseY) {
-        int areaX = (x + mouseX / MapData.TILE_WIDTH) / 8, areaY = (y + mouseY
+        int areaX = (screenX + mouseX / MapData.TILE_WIDTH) / 8, areaY = (screenY + mouseY
                 / MapData.TILE_HEIGHT) / 8;
-        mouseX += (x % 8) * MapData.TILE_WIDTH;
+        mouseX += (screenX % 8) * MapData.TILE_WIDTH;
         mouseX %= (MapData.TILE_WIDTH * 8);
-        mouseY += (y % 8) * MapData.TILE_HEIGHT;
+        mouseY += (screenY % 8) * MapData.TILE_HEIGHT;
         mouseY %= (MapData.TILE_HEIGHT * 8);
         return map.popDoorFromCoords(areaX, areaY, mouseX / 8, mouseY / 8);
     }
 
     private void pushDoorFromMouseXY(MapData.Door door, int mouseX,
                                      int mouseY) {
-        int areaX = (x + mouseX / MapData.TILE_WIDTH) / 8, areaY = (y + mouseY
+        int areaX = (screenX + mouseX / MapData.TILE_WIDTH) / 8, areaY = (screenY + mouseY
                 / MapData.TILE_HEIGHT) / 8;
-        mouseX += (x % 8) * MapData.TILE_WIDTH;
+        mouseX += (screenX % 8) * MapData.TILE_WIDTH;
         mouseX %= (MapData.TILE_WIDTH * 8);
-        mouseY += (y % 8) * MapData.TILE_HEIGHT;
+        mouseY += (screenY % 8) * MapData.TILE_HEIGHT;
         mouseY %= (MapData.TILE_HEIGHT * 8);
         door.x = mouseX / 8;
         door.y = mouseY / 8;
@@ -1018,14 +1017,14 @@ public class MapDisplay extends AbstractButton implements
     private void updateCoordLabels(final int mouseX, final int mouseY) {
         if ((mouseX >= 0) && (mouseY >= 0)) {
             pixelCoordLabel.setText("Pixel X,Y: ("
-                    + (x * MapData.TILE_WIDTH + mouseX - 1) + ","
-                    + (y * MapData.TILE_WIDTH + mouseY - 1) + ")");
+                    + (screenX * MapData.TILE_WIDTH + mouseX - 1) + ","
+                    + (screenY * MapData.TILE_WIDTH + mouseY - 1) + ")");
             warpCoordLabel.setText("Warp X,Y: ("
-                    + (x * 4 + (mouseX - 1) / 8) + ","
-                    + (y * 4 + (mouseY - 1) / 8) + ")");
+                    + (screenX * 4 + (mouseX - 1) / 8) + ","
+                    + (screenY * 4 + (mouseY - 1) / 8) + ")");
             tileCoordLabel.setText("Tile X,Y: ("
-                    + (x + (mouseX - 1) / MapData.TILE_WIDTH) + ","
-                    + (y + (mouseY - 1) / MapData.TILE_HEIGHT) + ")");
+                    + (screenX + (mouseX - 1) / MapData.TILE_WIDTH) + ","
+                    + (screenY + (mouseY - 1) / MapData.TILE_HEIGHT) + ")");
         }
     }
 
@@ -1121,7 +1120,7 @@ public class MapDisplay extends AbstractButton implements
             screenWidth = newSW;
             screenHeight = newSH;
 
-            setMapXY(x, y);
+            setMapXY(screenX, screenY);
 
             setPreferredSize(new Dimension(screenWidth * MapData.TILE_WIDTH
                     + 2, screenHeight * MapData.TILE_HEIGHT + 2));


### PR DESCRIPTION
Adds per-pixel scrolling to the map editor. This allows the screen to scroll past the map bounds. This in turn lets the door editor jump to consistent coordinates.

Also contains a lot of cleanup. The final commit is the new stuff.

Please check that this works before approving - I might've missed adding a file due to the dumb setup I'm using. I also might've missed a UI flow when testing the change.