### PR TITLE
Add teleport editing

### DIFF
--- a/src/ebhack/CustomSectorEditor.java
+++ b/src/ebhack/CustomSectorEditor.java
@@ -1,0 +1,155 @@
+package ebhack;
+
+import ebhack.types.CustomSectorData;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomSectorEditor extends JPanel {
+    private final CustomSectorData sectorData;
+    private final MapData mapData;
+    private final MapDisplay mapDisplay;
+    private final Map<String, FieldData> fieldData = new HashMap<>();
+    private Point sectorCoords = new Point(0, 0);
+    public CustomSectorEditor(MapDisplay mapDisplay, MapData mapData) {
+        this.mapDisplay = mapDisplay;
+        this.mapData = mapData;
+        sectorData = mapData.getCustomSectorData();
+        setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
+        // Properties up top
+        for (String key : sectorData.getKeys()) {
+            add(new FieldData(key, sectorData.getDefault(key)));
+        }
+        // Box is just a Swing layout spacer.
+        add(Box.createVerticalGlue());
+        // Button to add new fields
+        JButton addFieldButton = new JButton("Add field");
+        addFieldButton.addActionListener(actionEvent -> showAddFieldDialog());
+        add(addFieldButton);
+        // Put some width on our preferred size for when empty
+        setPreferredSize(new Dimension(200, 10));
+    }
+
+    private void showAddFieldDialog() {
+        // Build the option pane
+        final JTextField inputKey = new JTextField();
+        final JComboBox<String> inputType = new JComboBox<>();
+        inputType.addItem("byte");
+        inputType.addItem("short");
+        inputType.addItem("long");
+        final JTextField inputDefault = new JTextField();
+        final Object[] message = {
+                "CCS Label:", inputKey,
+                "Type:", inputType,
+                "Default value:", inputDefault
+        };
+        // Keep trying until the user gives up or gets it right
+        boolean valid = false;
+        while (!valid) {
+            int option = JOptionPane.showConfirmDialog(this, message, "Add field", JOptionPane.OK_CANCEL_OPTION);
+            if (option != JOptionPane.OK_OPTION) {
+                return;
+            }
+            // Validate
+            valid = true;
+            if (!inputKey.getText().matches("[_A-Za-z][_A-Za-z0-9]*")) {
+                JOptionPane.showMessageDialog(this,
+                        "Invalid CCS label (ThisIsAValidOne).");
+                valid = false;
+                continue;
+            }
+            if (sectorData.containsKey(inputKey.getText())) {
+                JOptionPane.showMessageDialog(this,
+                        "CCS label already exists.");
+                valid = false;
+                continue;
+            }
+            if (inputDefault.getText().trim().isEmpty()) {
+                JOptionPane.showMessageDialog(this,
+                        "Default value can't be empty.");
+                valid = false;
+                continue;
+            }
+        }
+
+        // Add this sector to our dataset
+        String key = inputKey.getText();
+        String type = (String) inputType.getSelectedItem();
+        String defaultValue = inputDefault.getText();
+        sectorData.createProperty(key, type, defaultValue, mapData.getSectorCount());
+
+        // Insert before the spacer and this button
+        int index = getComponentCount() - 2;
+        add(new FieldData(key, defaultValue), index);
+        revalidate();
+
+        // Map display needs to show the field
+        mapDisplay.repaint();
+    }
+
+    public void setSectorCoords(Point sectorCoords) {
+        this.sectorCoords = sectorCoords;
+        for (String key : sectorData.getKeys()) {
+            FieldData data = fieldData.get(key);
+            data.field.setEnabled(sectorCoords != null);
+            if (sectorCoords == null) {
+                data.field.setText("");
+            } else {
+                data.field.setText(sectorData.getSectorValue(key, sectorCoords));
+            }
+        }
+    }
+
+    /**
+     * Gui container for one label/field pair for a custom sector component.
+     */
+    private class FieldData extends JPanel {
+        private final String key;
+        private final JTextField field;
+        private FieldData(String key, String defaultValue) {
+            this.key = key;
+            fieldData.put(key, this);
+            add(new JLabel(key + ": "));
+            field = new JTextField();
+            field.setText(defaultValue);
+            field.getDocument().addDocumentListener(new DocumentListener() {
+                // Yeah this interface is dumb and overengineered.
+                @Override
+                public void insertUpdate(DocumentEvent documentEvent) {
+                    updateValue();
+                }
+                @Override
+                public void removeUpdate(DocumentEvent documentEvent) {
+                    updateValue();
+                }
+                @Override
+                public void changedUpdate(DocumentEvent documentEvent) {
+                    updateValue();
+                }
+            });
+            // Text field needs a preferred size to not be tiny
+            field.setPreferredSize(new Dimension(100, 16));
+            field.setMinimumSize(new Dimension(50, 16));
+            add(field);
+            // Box layout needs a max vertical size to not stretch out awkwardly
+            // needs two line heights in case Java decides to wrap the label
+            setMaximumSize(new Dimension(400, 100));
+        }
+        private void updateValue() {
+            String val = field.getText();
+            if (!val.trim().isEmpty() && sectorCoords != null) {
+                sectorData.setSectorValue(key, sectorCoords, val);
+                mapDisplay.repaint();
+            }
+
+        }
+
+    }
+
+}

--- a/src/ebhack/MapData.java
+++ b/src/ebhack/MapData.java
@@ -52,6 +52,16 @@ public class MapData {
         hotspots = new Hotspot[56];
         for (int i = 0; i < hotspots.length; ++i)
             hotspots[i] = new Hotspot();
+
+        mapTiles.clear();
+        sectors.clear();
+        spriteAreas.clear();
+        doorAreas.clear();
+        enemyPlacement.clear();
+        mapEnemyGroups.clear();
+        enemyGroups.clear();
+        enemyOverworldSprites.clear();
+        enemySpriteImages.clear();
     }
 
     public void load(Project proj) {

--- a/src/ebhack/MapDisplay.java
+++ b/src/ebhack/MapDisplay.java
@@ -197,6 +197,14 @@ public class MapDisplay extends AbstractButton implements
         setPreferredSize(new Dimension(
                 screenWidth * MapData.TILE_WIDTH + 2, screenHeight
                 * MapData.TILE_HEIGHT + 2));
+
+        // Call screen resize whenever we get resized
+        addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e) {
+                resetScreenSize();
+            }
+        });
     }
 
     public void init() {
@@ -265,10 +273,14 @@ public class MapDisplay extends AbstractButton implements
             }
         }
 
-        if (grid && !gamePreview && !currentMode.drawEnemies())
+        if (currentMode == MapMode.CUSTOM_SECTOR) {
+            drawSectorDetails(g);
+        }
+
+        if (grid && !gamePreview && !currentMode.drawEnemies() && currentMode != MapMode.CUSTOM_SECTOR)
             drawGrid(g);
 
-        if (currentMode == MapMode.MAP && (selectedSector != null)) {
+        if (currentMode.drawSectors() && (selectedSector != null)) {
             int sXt, sYt;
             if (((sXt = sectorX * MapData.SECTOR_WIDTH)
                     + MapData.SECTOR_WIDTH >= screenX)
@@ -473,6 +485,55 @@ public class MapDisplay extends AbstractButton implements
             g.drawImage(map.getSpriteImage(1, 2), tvPreviewX - 7,
                     tvPreviewY - 15, this);
         }
+    }
+
+    private void drawSectorDetails(Graphics2D g) {
+        // Translations to undo the weird coords the rest of the editor is on
+        int translateX = -screenX * MapData.TILE_WIDTH;
+        int translateY = -screenY * MapData.TILE_WIDTH;
+        // Draw sectors on screen
+        for (int sx = screenX / MapData.SECTOR_WIDTH; sx <= (screenX + screenWidth) / MapData.SECTOR_WIDTH; sx++) {
+            if (sx >= MapData.WIDTH_IN_SECTORS) {
+                break;
+            }
+            for (int sy = screenY / MapData.SECTOR_HEIGHT; sy <= (screenY + screenHeight) / MapData.SECTOR_HEIGHT; sy++) {
+                if (sy >= map.getHeightInSectors()) {
+                    break;
+                }
+                // Get screen coords
+                int x = sx * MapData.SECTOR_WIDTH_IN_PIXELS+ translateX;
+                int y = sy * MapData.SECTOR_HEIGHT_IN_PIXELS + translateY;
+                // Draw grid
+                g.setPaint(Color.black);
+                g.drawRect(x, y, MapData.SECTOR_WIDTH_IN_PIXELS, MapData.SECTOR_HEIGHT_IN_PIXELS);
+                // Draw coordinate label
+                String label = String.format("(%d, %d)", sx, sy);
+                Rectangle2D textBG = g.getFontMetrics().getStringBounds(label, g);
+                g.setPaint(Color.black);
+                g.fillRect(x, y, (int) textBG.getWidth(), (int) textBG.getHeight());
+                g.setPaint(Color.white);
+                g.drawString(label, x, (int) (y + textBG.getHeight()));
+                // Draw all other properties
+                Point drawNext = new Point(0, (int) textBG.getHeight());
+                for (String property : map.getCustomSectorData().getKeys()) {
+                    String value = map.getCustomSectorData().getSectorValue(property, new Point(sx, sy));
+                    label = String.format("%s: %s", property, value);
+                    textBG = g.getFontMetrics().getStringBounds(label, g);
+                    drawNext.y += (int) textBG.getHeight();
+                    if (drawNext.y > MapData.SECTOR_HEIGHT_IN_PIXELS) {
+                        // Format as two columns
+                        // (and honestly, if that's not enough, you're in too deep)
+                        drawNext.y = (int) textBG.getHeight();
+                        drawNext.x += MapData.SECTOR_WIDTH_IN_PIXELS / 2;
+                    }
+                    g.setColor(Color.darkGray);
+                    g.fillRect(x + drawNext.x, y + drawNext.y - (int) textBG.getHeight(), (int) textBG.getWidth(), (int) textBG.getHeight());
+                    g.setPaint(Color.white);
+                    g.drawString(label, x + drawNext.x, y + drawNext.y);
+                }
+            }
+        }
+
     }
 
     public void drawEnemyPlate(Graphics2D g, Rectangle2D rect, int mapEnemyGroupId) {
@@ -758,7 +819,7 @@ public class MapDisplay extends AbstractButton implements
             int invZoom = (int) (1.0 / zoom);
             invZoom -= delta;
             invZoom = Math.max(1, invZoom);
-            invZoom = Math.min(8, invZoom);
+            invZoom = Math.min(4, invZoom);
             zoom = 1.0 / invZoom;
         }
         // Adjust scroll so worldX/worldY stay the same
@@ -951,6 +1012,14 @@ public class MapDisplay extends AbstractButton implements
                         }
                     }
                 }
+            } else if (currentMode == MapMode.CUSTOM_SECTOR) {
+                // Don't check what button
+                // Make sure they didn't click on the border
+                int sX = (screenX + ((mouseX - 1) / MapData.TILE_WIDTH))
+                        / MapData.SECTOR_WIDTH;
+                int sY = (screenY + ((mouseY - 1) / MapData.TILE_HEIGHT))
+                        / MapData.SECTOR_HEIGHT;
+                selectSector(sX, sY);
             }
         }
     }

--- a/src/ebhack/MapDisplay.java
+++ b/src/ebhack/MapDisplay.java
@@ -679,7 +679,7 @@ public class MapDisplay extends AbstractButton implements
 
     public int getMaxScrollY() {
         // Half the screen below the map
-        int mapSize = MapData.HEIGHT_IN_TILES * MapData.TILE_WIDTH;
+        int mapSize = map.getHeightInPixels();
         int screenSize = (int) (getSize().height / (2 * zoom));
         return mapSize - screenSize;
     }
@@ -704,7 +704,7 @@ public class MapDisplay extends AbstractButton implements
         tileX = Math.max(0, tileX);
         tileY = Math.max(0, tileY);
         this.screenX = Math.min(tileX, MapData.WIDTH_IN_TILES - screenWidth);
-        this.screenY = Math.min(tileY, MapData.HEIGHT_IN_TILES - screenHeight);
+        this.screenY = Math.min(tileY, map.getHeightInTiles() - screenHeight);
     }
 
     public void centerScroll(int x, int y) {
@@ -1343,7 +1343,7 @@ public class MapDisplay extends AbstractButton implements
         newSW = (int) Math.ceil(newSW / zoom);
         newSH = (int) Math.ceil(newSH / zoom);
         newSW = Math.min(newSW, MapData.WIDTH_IN_TILES);
-        newSH = Math.min(newSH, MapData.HEIGHT_IN_TILES);
+        newSH = Math.min(newSH, map.getHeightInTiles());
         if ((newSW != screenWidth) || (newSH != screenHeight)) {
             screenWidth = newSW;
             screenHeight = newSH;

--- a/src/ebhack/MapDisplay.java
+++ b/src/ebhack/MapDisplay.java
@@ -1,7 +1,6 @@
 package ebhack;
 
-import ebhack.types.EnemyGroup;
-import ebhack.types.MapEnemyGroup;
+import ebhack.types.*;
 
 import javax.swing.*;
 import java.awt.*;
@@ -82,6 +81,7 @@ public class MapDisplay extends AbstractButton implements
     private Image movingNPCimg;
     private Integer[] movingNPCdim;
     private MapData.Door movingDoor = null;
+    private TileObject movingTeleport = null;
 
     // Popup menus
     private int popupX, popupY;
@@ -452,6 +452,10 @@ public class MapDisplay extends AbstractButton implements
             }
         }
 
+        if (currentMode.drawTeleports()) {
+            drawTeleports(g);
+        }
+
         if (gamePreview && tvPreview) {
             g.setComposite(AlphaComposite.getInstance(
                     AlphaComposite.SRC_OVER, 1.0F));
@@ -564,6 +568,46 @@ public class MapDisplay extends AbstractButton implements
     private double enemySpriteZoom() {
         double maxZoom = enemyBattleSprites ? 7 : 4;;
         return Math.min(zoom, maxZoom);
+    }
+
+    private void drawTeleports(Graphics2D g) {
+        int translateX = -screenX * MapData.TILE_WIDTH;
+        int translateY = -screenY * MapData.TILE_WIDTH;
+        for (TeleportDestination dest : map.getTeleportDestinations()) {
+            int x = dest.x * 8 + translateX;
+            int y = dest.y * 8 + translateY;
+            // Draw a label for the teleport number
+            String label = Integer.toString(dest.id);
+            Rectangle2D textBG = g.getFontMetrics().getStringBounds(label, g);
+            g.setPaint(new Color(3, 13, 42));
+            g.fillRect(x + 8, y, (int) textBG.getWidth(), (int) textBG.getHeight());
+            g.setColor(Color.white);
+            g.drawString(label, x + 8, (int) (y + textBG.getHeight()));
+            // Draw some sort of teleport icon
+            g.setPaint(new Color(3, 13, 42));
+            g.fillRect(x, y, 9, 9);
+            for (int ring = 0; ring < 4; ring+=2) {
+                g.setPaint(new Color(70, 113, 220));
+                g.fillOval(x + ring, y + ring, 9 - ring * 2, 9 - ring * 2);
+                g.setPaint(new Color(29, 54, 89));
+                g.fillOval(x + ring + 1, y + ring + 1, 7 - ring * 2, 7 - ring * 2);
+            }
+        }
+        Image teleportImage = map.getSpriteImage(13, 2);
+        for (PsiTeleportDestination dest : map.getPsiTeleportDestinations()) {
+            int x = dest.x * 8 + translateX;
+            int y = dest.y * 8 + translateY;
+            // Draw some sort of teleport icon
+            g.drawImage(teleportImage, x, y, null);
+            // Draw a label for the teleport number
+            x += teleportImage.getWidth(null);
+            String label = dest.id + " - " + dest.name;
+            Rectangle2D textBG = g.getFontMetrics().getStringBounds(label, g);
+            g.setPaint(new Color(3, 13, 42));
+            g.fillRect(x, y, (int) textBG.getWidth(), (int) textBG.getHeight());
+            g.setColor(Color.white);
+            g.drawString(label, x, (int) (y + textBG.getHeight()));
+        }
     }
 
     private void drawNumber(Graphics2D g, int n, int x, int y, boolean hex,
@@ -1137,6 +1181,25 @@ public class MapDisplay extends AbstractButton implements
                     movingDrawY = my & (~7);
                     repaint();
                 }
+            } else if (currentMode == MapMode.TELEPORT && (movingTeleport == null)) {
+                // Use world coordinates; mouse coords are a silly thing to be backwards
+                // compatible with the old tile-based coordinates.
+                int worldX = (int) (e.getX() / zoom + scrollX);
+                int worldY = (int) (e.getY() / zoom + scrollY);
+                int tileX = worldX / 8;
+                int tileY = worldY / 8;
+                for (TeleportDestination dest : map.getTeleportDestinations()) {
+                    if (dest.x == tileX && dest.y == tileY) {
+                        movingTeleport = dest;
+                    }
+                }
+                for (PsiTeleportDestination dest : map.getPsiTeleportDestinations()) {
+                    // The teleport graphic is 2x3 tiles
+                    if (tileX >= dest.x && tileX <= dest.x + 1
+                            && tileY >= dest.y && tileY <= dest.y + 2) {
+                        movingTeleport = dest;
+                    }
+                }
             }
         }
     }
@@ -1161,6 +1224,7 @@ public class MapDisplay extends AbstractButton implements
                 movingDoor = null;
                 repaint();
             }
+            movingTeleport = null;
         }
     }
 
@@ -1195,6 +1259,18 @@ public class MapDisplay extends AbstractButton implements
         } else if (movingDoor != null) {
             movingDrawX = mouseX & (~7);
             movingDrawY = mouseY & (~7);
+            repaint();
+        } else if (movingTeleport != null) {
+            int worldX = (int) (e.getX() / zoom + scrollX);
+            int worldY = (int) (e.getY() / zoom + scrollY);
+            int tileX = worldX / 8;
+            int tileY = worldY / 8;
+            tileX = Math.max(0, tileX);
+            tileY = Math.max(0, tileY);
+            tileX = Math.min(MapData.WIDTH_IN_TILES * 4 - 1, tileX);
+            tileY = Math.min(MapData.HEIGHT_IN_TILES * 4 - 1, tileY);
+            movingTeleport.x = tileX;
+            movingTeleport.y = tileY;
             repaint();
         } else if (mouseDragButton == 2) {
             setMapXYPixel(scrollX - deltaX / zoom, scrollY - deltaY / zoom);

--- a/src/ebhack/MapEditor.java
+++ b/src/ebhack/MapEditor.java
@@ -233,7 +233,7 @@ public class MapEditor extends ToolModule implements ActionListener,
 		panel.add(xField);
 		panel.add(new JLabel("Y: "));
 		yField = ToolModule.createSizedJTextField(
-				Integer.toString(MapData.HEIGHT_IN_TILES).length(), true);
+				Integer.toString(160).length(), true);
 		panel.add(yField);
 		panel.add(new JLabel("Tileset: "));
 		tilesetChooser = new JComboBox();
@@ -341,7 +341,7 @@ public class MapEditor extends ToolModule implements ActionListener,
 		xScroll.addAdjustmentListener(this);
 		contentPanel.add(xScroll, BorderLayout.SOUTH);
 		yScroll = new JScrollBar(JScrollBar.VERTICAL, 0,
-				mapDisplay.getScreenHeight(), 0, MapData.HEIGHT_IN_TILES);
+				mapDisplay.getScreenHeight(), 0, 80);
 		yScroll.addAdjustmentListener(this);
 		contentPanel.add(yScroll, BorderLayout.EAST);
 
@@ -887,9 +887,9 @@ public class MapEditor extends ToolModule implements ActionListener,
             final JTextField inputX2 = ToolModule.createSizedJTextField(
                     Integer.toString(MapData.WIDTH_IN_TILES).length(), true);
             final JTextField inputY = ToolModule.createSizedJTextField(
-                    Integer.toString(MapData.HEIGHT_IN_TILES).length(), true);
+                    Integer.toString(999).length(), true);
             final JTextField inputY2 = ToolModule.createSizedJTextField(
-                    Integer.toString(MapData.HEIGHT_IN_TILES).length(), true);
+                    Integer.toString(999).length(), true);
             final Object[] message = {
                     "X1:", inputX,
                     "Y1:", inputY,
@@ -982,8 +982,8 @@ public class MapEditor extends ToolModule implements ActionListener,
 			} else if (newX < 0) {
 				newX = 0;
 			}
-			if (newY > MapData.HEIGHT_IN_TILES - mapDisplay.getScreenHeight()) {
-				newY = MapData.HEIGHT_IN_TILES - mapDisplay.getScreenHeight();
+			if (newY > map.getHeightInTiles() - mapDisplay.getScreenHeight()) {
+				newY = map.getHeightInTiles() - mapDisplay.getScreenHeight();
 			} else if (newY < 0) {
 				newY = 0;
 			}

--- a/src/ebhack/MapEditor.java
+++ b/src/ebhack/MapEditor.java
@@ -135,6 +135,13 @@ public class MapEditor extends ToolModule implements ActionListener,
 		radioButton.addActionListener(this);
 		group.add(radioButton);
 		modeMenu.add(radioButton);
+		radioButton = new JRadioButtonMenuItem("Teleport Edit");
+		radioButton.setAccelerator(KeyStroke.getKeyStroke("F8"));
+		radioButton.setSelected(true);
+		radioButton.setActionCommand("modeteleport");
+		radioButton.addActionListener(this);
+		group.add(radioButton);
+		modeMenu.add(radioButton);
 		radioButton = new JRadioButtonMenuItem("Whole View");
 		radioButton.setAccelerator(KeyStroke.getKeyStroke("F6"));
 		radioButton.setSelected(true);
@@ -700,6 +707,11 @@ public class MapEditor extends ToolModule implements ActionListener,
 			mapDisplay.changeMode(MapMode.PREVIEW);
 			mapDisplay.repaint();
 			tileSelector.changeMode(MapMode.PREVIEW);
+			tileSelector.repaint();
+		} else if (e.getActionCommand().equals("modeteleport")) {
+			mapDisplay.changeMode(MapMode.TELEPORT);
+			mapDisplay.repaint();
+			tileSelector.changeMode(MapMode.TELEPORT);
 			tileSelector.repaint();
 		} else if (e.getActionCommand().equals("delAllSprites")) {
 			int sure = JOptionPane

--- a/src/ebhack/MapEditor.java
+++ b/src/ebhack/MapEditor.java
@@ -214,8 +214,10 @@ public class MapEditor extends ToolModule implements ActionListener,
 		menuBar.add(menu);
 
         menu = new JMenu("Tools");
-        menu.add(ToolModule.createJMenuItem("Export as Image", 'i', "control i",
-                "exportAsImage", this));
+		menu.add(ToolModule.createJMenuItem("Expand map", 'i', null,
+				"expandMap", this));
+		menu.add(ToolModule.createJMenuItem("Export as Image", 'i', "control i",
+				"exportAsImage", this));
         menuBar.add(menu);
 
 		mainWindow.setJMenuBar(menuBar);
@@ -881,6 +883,12 @@ public class MapEditor extends ToolModule implements ActionListener,
 						"There are no actions to redo.", "Error",
 						JOptionPane.ERROR_MESSAGE);
 			}
+		} else if (e.getActionCommand().equals("expandMap")) {
+			map.expandMap();
+			// TODO: why is setting xy pixel to itself needed here? Doesn't repaint if you don't.
+			mapDisplay.setMapXYPixel(mapDisplay.getScrollX(), mapDisplay.getScrollY());
+			mapDisplay.repaint();
+			updateXYScrollBars();
 		} else if (e.getActionCommand().equals("exportAsImage")) {
             final JTextField inputX = ToolModule.createSizedJTextField(
                     Integer.toString(MapData.WIDTH_IN_TILES).length(), true);

--- a/src/ebhack/MapMode.java
+++ b/src/ebhack/MapMode.java
@@ -10,7 +10,8 @@ public enum MapMode {
     HOTSPOT, // 6
     ENEMY, // 7
     VIEW_ALL, // 8
-    PREVIEW; // 9
+    PREVIEW, // 9
+    CUSTOM_SECTOR;
 
     public boolean drawSprites() {
         return this == SPRITE || this == SEEK_DOOR
@@ -27,4 +28,7 @@ public enum MapMode {
     public boolean drawHotspots() {
         return this == HOTSPOT || this == VIEW_ALL;
     }
+    public boolean drawSectors() { return this == MAP || this == CUSTOM_SECTOR; }
+
+    public boolean showTileSelector() { return this == MAP || this == ENEMY; }
 }

--- a/src/ebhack/types/CustomSectorData.java
+++ b/src/ebhack/types/CustomSectorData.java
@@ -1,0 +1,123 @@
+package ebhack.types;
+
+import ebhack.MapData;
+
+import java.awt.*;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.*;
+import java.util.List;
+
+public class CustomSectorData {
+    public static final String sectorDataPath = File.separator + "ccscript" + File.separator + "custom_sector_data.ccs";
+    private final Map<String, SectorProperty> properties = new LinkedHashMap<>();
+    public CustomSectorData() {}
+
+    public Collection<String> getKeys() {
+        return properties.keySet();
+    }
+
+    public boolean containsKey(String key) {
+        return properties.containsKey(key);
+    }
+
+    public void load(InputStream inStream) {
+        Scanner in = new Scanner(inStream);
+        while (in.hasNextLine()) {
+            String line = in.nextLine();
+            if (line.startsWith("// Type")) {
+                loadProperty(line, in);
+            }
+        }
+    }
+
+    public void clear() {
+        properties.clear();
+    }
+
+    public void write(OutputStream outStream) {
+        PrintStream out = new PrintStream(outStream);
+        out.println("// Hey! Be very careful if you edit this manually; it's designed so EbProjectEditor can read it.");
+        out.println();
+        for (Map.Entry<String, SectorProperty> sectorEntry : properties.entrySet()) {
+            String key = sectorEntry.getKey();
+            SectorProperty property = sectorEntry.getValue();
+            property.write(key, out);
+            out.println();
+        }
+    }
+
+    public void createProperty(String key, String type, String defaultValue, int sectorCount) {
+        SectorProperty property = new SectorProperty(type, defaultValue);
+        properties.put(key, property);
+        for (int i = 0; i < sectorCount; i++) {
+            property.values.add(defaultValue);
+        }
+    }
+
+    private void loadProperty(String firstLine, Scanner in) {
+        // Read a type header
+        String type = firstLine.substring(("// Type: ".length()));
+        String defaultLine = in.nextLine();
+        String defaultValue = defaultLine.substring("// Default: ".length());
+        String keyLine = in.nextLine();
+        String key = keyLine.substring(0, keyLine.indexOf(":"));
+        SectorProperty property = new SectorProperty(type, defaultValue);
+        properties.put(key, property);
+        // Read values until we hit a blank line
+        String nextLine = in.nextLine();
+        while (in.hasNextLine() && !nextLine.isEmpty()) {
+            String value = nextLine.substring(type.length() + 3);
+            property.values.add(value);
+            nextLine = in.nextLine();
+        }
+    }
+
+    public String getDefault(String key) {
+        return properties.get(key).defaultValue;
+    }
+
+    public String getSectorValue(String key, Point sectorCoords) {
+        SectorProperty property = properties.get(key);
+        int index = sectorCoords.x + sectorCoords.y * MapData.WIDTH_IN_SECTORS;
+        return property.values.get(index);
+    }
+
+    public void setSectorValue(String key, Point sectorCoords, String value) {
+        SectorProperty property = properties.get(key);
+        int index = sectorCoords.x + sectorCoords.y * MapData.WIDTH_IN_SECTORS;
+        property.values.set(index, value);
+    }
+
+    public void extend(int rows) {
+        for (SectorProperty property : properties.values()) {
+            for (int i = 0; i < rows; i++) {
+                for (int j = 0; j < MapData.WIDTH_IN_SECTORS; j++) {
+                    property.values.add(property.defaultValue);
+                }
+            }
+        }
+    }
+
+    private static class SectorProperty {
+        String type;
+        String defaultValue;
+        List<String> values = new ArrayList<>();
+
+        private SectorProperty(String type, String defaultValue) {
+            this.type = type;
+            this.defaultValue = defaultValue;
+        }
+
+        private void write(String key, PrintStream out) {
+            out.println("// Type: " + this.type);
+            out.println("// Default: " + this.defaultValue);
+            out.println(key + ":");
+            for (String value : values) {
+                out.println("  " + type + " " + value);
+            }
+        }
+    }
+}

--- a/src/ebhack/types/PsiTeleportDestination.java
+++ b/src/ebhack/types/PsiTeleportDestination.java
@@ -1,0 +1,33 @@
+package ebhack.types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PsiTeleportDestination extends TileObject {
+    public int id;
+    public int eventFlag;
+    public String name;
+
+    // Note: this is intended to be constructed using the object that gets
+    // spit out by SnakeYaml.
+    public PsiTeleportDestination(int id, Object deserialize) {
+        this.id = id;
+        Map<String, Object> top = (Map<String, Object>) deserialize;
+        eventFlag = (int) top.get("Event Flag");
+        name = (String) top.get("Name");
+        x = (int) top.get("X");
+        y = (int) top.get("Y");
+    }
+
+    // Exports this to an object that Snakeyaml knows how to serialize.
+    // (in this case it's a HashMap, but could be a nested HashMap nightmare
+    // for different ones.)
+    public Object serialize() {
+        HashMap<String, Object> result = new HashMap<>();
+        result.put("Event Flag", eventFlag);
+        result.put("Name", name);
+        result.put("X", x);
+        result.put("Y", y);
+        return result;
+    }
+}

--- a/src/ebhack/types/TeleportDestination.java
+++ b/src/ebhack/types/TeleportDestination.java
@@ -1,0 +1,36 @@
+package ebhack.types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TeleportDestination extends TileObject  {
+    public int id;
+    public int direction;
+    public int unknown;
+    public int warpStyle;
+
+    // Note: this is intended to be constructed using the object that gets
+    // spit out by SnakeYaml.
+    public TeleportDestination(int id, Object deserialize) {
+        this.id = id;
+        Map<String, Object> top = (Map<String, Object>) deserialize;
+        direction = (int) top.get("Direction");
+        unknown = (int) top.get("Unknown");
+        warpStyle = (int) top.get("Warp Style");
+        x = (int) top.get("X");
+        y = (int) top.get("Y");
+    }
+
+    // Exports this to an object that Snakeyaml knows how to serialize.
+    // (in this case it's a HashMap, but could be a nested HashMap nightmare
+    // for different ones.)
+    public Object serialize() {
+        HashMap<String, Integer> result = new HashMap<>();
+        result.put("Direction", direction);
+        result.put("Unknown", unknown);
+        result.put("Warp Style", warpStyle);
+        result.put("X", x);
+        result.put("Y", y);
+        return result;
+    }
+}

--- a/src/ebhack/types/TileObject.java
+++ b/src/ebhack/types/TileObject.java
@@ -1,0 +1,6 @@
+package ebhack.types;
+
+public class TileObject {
+    public int x;
+    public int y;
+}


### PR DESCRIPTION
(This one is after the enemy editor in the stack of branches.)

Adds editor for teleport_destinations_table and psi_teleport_dests.

I put them in the same mode; seems excessive to include two modes for some things that are conceptually similar, where one is quite rare.