### PR TITLE
Update pom.xml to include dependency and JAR-building-info, and add default IDEA run configuration

### DIFF
--- a/.idea/artifacts/EbProjEdit_jar.xml
+++ b/.idea/artifacts/EbProjEdit_jar.xml
@@ -1,9 +1,0 @@
-<component name="ArtifactManager">
-  <artifact type="jar" build-on-make="true" name="EbProjEdit:jar">
-    <output-path>$PROJECT_DIR$/out/artifacts/EbProjEdit_jar</output-path>
-    <root id="archive" name="EbProjEdit.jar">
-      <element id="module-output" name="EbProjEdit" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/yaml/snakeyaml/2.2/snakeyaml-2.2.jar" path-in-jar="/" />
-    </root>
-  </artifact>
-</component>

--- a/.idea/runConfigurations/EbProjEdit_JAR_with_Dependencies.xml
+++ b/.idea/runConfigurations/EbProjEdit_JAR_with_Dependencies.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="EbProjEdit JAR with Dependencies" type="JarApplication">
+    <option name="JAR_PATH" value="$PROJECT_DIR$/target/EbProjEdit-1.0-SNAPSHOT-jar-with-dependencies.jar" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <method v="2">
+      <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/pom.xml" goal="package" />
+    </method>
+  </configuration>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,41 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <defaultGoal>package</defaultGoal>
+        <plugins>
+            <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <archive>
+                    <manifest>
+                        <addClasspath>true</addClasspath>
+                        <mainClass>ebhack.Ebhack</mainClass>
+                    </manifest>
+                </archive>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+            </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
This allows users to easily build and run the project by doing as follows:
1. Cloning the repository / checking out this branch
2. Opening IntelliJ IDEA and opening the project
3. Ensuring the "EbProjEdit JAR with Dependencies" run configuration is selected
4. Hit Run

This will create a .JAR file with all dependencies included for ease of distribution.