### PR TITLE
Create maven.yml and update Readme

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,30 @@
+name: Maven Verify
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        architecture: x64
+        cache: maven
+    - name: Test and build Maven project
+      run: mvn --batch-mode --update-snapshots verify --file pom.xml
+    - name: Upload build artifact
+      run: mkdir staging && cp target/*-jar-with-dependencies.jar staging
+    - uses: actions/upload-artifact@v4
+      with:
+       name: Build
+       path: staging

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 ## EB Project Editor
+![maven workflow badge](https://github.com/pk-hack/EbProjectEditor/actions/workflows/maven.yml/badge.svg?branch=main)
+
+[Latest Development Build](https://nightly.link/pk-hack/EbProjectEditor/workflows/maven/main/Build.zip)
 
 EB Project Editor is a graphical Java application used to edit projects created with [CoilSnake](https://pk-hack.github.io/CoilSnake/), the most powerful mod making tool for the game EarthBound. It's distributed as part of CoilSnake, but it's actually an independent application. 


### PR DESCRIPTION
Creates a maven verify Github actions workflow on successful pull request or on push. The links in the readme should link to the latest build artifact produced by this action. It will take a little setup from the repository owner on [nightly.link](https://nightly.link/) to connect the nightly github app to the account and select the repository. After a successful workflow has run the badge in the readme will update.