### PR TITLE
Fix for enemy groups out of bound.

### DIFF
--- a/src/main/java/ebhack/MapData.java
+++ b/src/main/java/ebhack/MapData.java
@@ -127,7 +127,7 @@ public class MapData {
     }
 
     public EnemyGroup getEnemyGroup(int n) {
-        return enemyGroups.get(n);
+        return n < enemyGroups.size() ? enemyGroups.get(n) : null;
     }
 
     public MapEnemyGroup getMapEnemyGroup(int n) {

--- a/src/main/java/ebhack/MapDisplay.java
+++ b/src/main/java/ebhack/MapDisplay.java
@@ -530,6 +530,8 @@ public class MapDisplay extends AbstractButton implements
      */
     public int drawEnemyGroup(Graphics2D g, Rectangle2D bounds, Point origin, int probability, int enemyGroupId) {
         EnemyGroup enemyGroup = map.getEnemyGroup(enemyGroupId);
+        if (enemyGroup == null)
+	        return 0;
         int maxX = origin.x;
         AffineTransform stashed = g.getTransform();
         g.translate(bounds.getX(), bounds.getY());


### PR DESCRIPTION
We can put enemy groups higher than 483 (default enemy groups limit) in map_enemy_groups.yml and CoilSnake will compile correctly, but we get a glitch with EbProjectEditor's Map Editor in Enemy Mode where we can't scroll across the map enemy groups that use these groups out of bounds.

This little change fixes that by making getEnemyGroup return null if the group is out of bounds and making drawEnemyGroup return 0 and therefore not do the drawing in that case.

This is useful if we are extending the enemy groups table and want to actually use groups past 483 without getting that glitch in EbProjectEditor.