### PR TITLE
Add Keepalive to github actions workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,3 +30,13 @@ jobs:
       with:
        name: Build
        path: staging
+  keepalive:
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    - cron: '15 0 28 * *'
 
 jobs:
   build:


### PR DESCRIPTION
Adds a cron job to run on the 28th day of each month that will build the latest development artifact.

The github actions workflow will disable itself if there is over 60 days of no repository activity and the keepalive workflow job will use the github API to refresh the workflow and keep it running indefinitely. 

Another solution would be to up the file to a separate location (like AWS S3), but after setting that up I realized that it would be too much of a hassle to set up and maintain. This is the...easier solution that should work with what has already been set up with the nightly link.